### PR TITLE
Added Swagger-Normalizer to list of vendor-documented extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ As well as a list of vendor-documented specification-extensions, this repository
 * [swaggerplusplus](https://github.com/mermade/swaggerplusplus)
 * [TypeForm OpenAPI-micro-merge](https://github.com/Typeform/openapi-micro-merge#extensions)
 * WaveMaker Studio (x-WM- extensions) - documentation pending
+* [RepreZen Swagger-Normalizer](http://docs.reprezen.com/swagger_normalizer/)
 
 ## Analysis of specification-extensions
 


### PR DESCRIPTION
At the user's option, Swagger-Normalizer may attach an `x-reprezen-normalization` property to specify element ordering.