### PR TITLE
Add api-ref-resolved, Bump.sh, Cadl

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ As well as a list of vendor-documented specification-extensions, this repository
 * [Apigee-127](https://github.com/apigee-127/a127-documentation/wiki/Swagger-specification-file#user-content-apigee-127-swagger-specification-reference)
 * [APIMatic](https://docs.apimatic.io/advanced/swagger-server-configuration-extensions/)
 * [APIs.guru](https://github.com/APIs-guru/openapi-directory/wiki/specification-extensions)
+* [Bump.sh](https://help.bump.sh/markdown-support#adding-topics-to-your-documentation)
 * [Bungie.net](https://github.com/Bungie-net/api#extension-properties-on-openapi-specs-or-how-to-generate-much-cooler-clients-for-the-bnet-api-if-you-want-to-take-the-time-to-do-so)
 * [Cadl](https://microsoft.github.io/cadl/next/standard-library/openapi/reference/js-api#getopenapitypename)
 * [DocuSign](https://github.com/docusign/eSign-OpenAPI-Specification/blob/master/DocuSign-Extensions.md)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ As well as a list of vendor-documented specification-extensions, this repository
 * [APIMatic](https://docs.apimatic.io/advanced/swagger-server-configuration-extensions/)
 * [APIs.guru](https://github.com/APIs-guru/openapi-directory/wiki/specification-extensions)
 * [Bungie.net](https://github.com/Bungie-net/api#extension-properties-on-openapi-specs-or-how-to-generate-much-cooler-clients-for-the-bnet-api-if-you-want-to-take-the-time-to-do-so)
+* [Cadl](https://microsoft.github.io/cadl/next/standard-library/openapi/reference/js-api#getopenapitypename)
 * [DocuSign](https://github.com/docusign/eSign-OpenAPI-Specification/blob/master/DocuSign-Extensions.md)
 * [EVRYTHNG](https://developers.evrythng.com/docs/openapi-description#section-extensions)
 * [Exegesis](https://github.com/exegesis-js/exegesis/blob/master/docs/OAS3%20Specification%20Extensions.md)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ As well as a list of vendor-documented specification-extensions, this repository
 * [AIRR](http://docs.airr-community.org/en/latest/datarep/overview.html#airr-extension-properties)
 * [Alibaba Cloud API Gateway](https://www.alibabacloud.com/help/doc-detail/88956.htm)
 * [Amazon AWS](http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions.html)
+* [api-ref-resolver](https://github.com/apiture/api-ref-resolver#readme)
 * [Apiary](https://help.apiary.io/api_101/swagger-extensions/)
 * [Apigee-127](https://github.com/apigee-127/a127-documentation/wiki/Swagger-specification-file#user-content-apigee-127-swagger-specification-reference)
 * [APIMatic](https://docs.apimatic.io/advanced/swagger-server-configuration-extensions/)


### PR DESCRIPTION
api-ref-resolver can emit `x-resolved-from` and `x-resolved-at`.

Bump.sh supports `x-topics`.

Cadl can emit `x-cadl-name`.